### PR TITLE
use a die directly in the @INC hook

### DIFF
--- a/lib/Acme/Devel/Hide/Tiny.pm
+++ b/lib/Acme/Devel/Hide/Tiny.pm
@@ -15,8 +15,8 @@ our $VERSION = '0.002';
 
     # hide Cpanel::JSON::XS -> Cpanel/JSON/XS.pm
     use lib map {
-        my ( $m, $c ) = ( $_, qq{die "Can't locate $_ (hidden)\n"} );
-        sub { return unless $_[1] eq $m; open my $fh, "<", \$c; return $fh }
+        my $m = $_;
+        sub { return unless $_[1] eq $m; die "Can't locate $_[1] in \@INC (hidden)\n"; }
     } qw{Cpanel/JSON/XS.pm};
 
 =head1 DESCRIPTION
@@ -26,8 +26,7 @@ development tools.  Unfortunately, using them in your F<.t> files adds a
 test dependency.  Maybe you don't want to do that.
 
 Instead, you can use the one-liner from the SYNOPSIS above, which is an
-extremely stripped down version of L<Devel::Hide>. B<NOTE>: this method
-only works on Perl v5.8.1 and later.
+extremely stripped down version of L<Devel::Hide>.
 
 Here is a more verbose, commented version of it:
 
@@ -36,22 +35,20 @@ Here is a more verbose, commented version of it:
 
         # add one coderef per path to hide
         map {
-            # create lexicals for module and fake module code; fake module
-            # code dies with the error message we want
-            my ( $m, $c ) = ( $_, qq{die "Can't locate $_ (hidden)\n"} );
+            # create lexical for module
+            my $m = $_;
 
-            # construct and return a closure that provides the fake module
-            # code only for the module path to hide
+            # construct and return a closure that dies for the module path to hide
             sub {
 
                 # return if not the path to hide; perl checks rest of @INC
                 return unless $_[1] eq $m;
 
-                # return a file handle to the fake module code
-                open my $fh, "<", \$c; return $fh
+                # die with the error message we want
+                die "Can't locate $_[1] in \@INC (hidden)\n";
             }
         }
-        
+
         # input to map is a list module names, converted to paths;
         qw{Cpanel/JSON/XS.pm JSON/XS.pm}
 
@@ -59,10 +56,10 @@ Here is a more verbose, commented version of it:
 
 When perl sees a coderef in C<@INC>, it gives the coderef a chance to
 provide the source code of that module.  In this case, if the path is the
-one we want to hide, it returns a handle to source code that dies with the
-message we want and perl won't continue looking at @<INC> to find the real
-module source.  The module is hidden and dies with a message similar to the
-one that would happen if it weren't installed.
+one we want to hide, it dies with the message we want and perl won't
+continue looking at C<@INC> to find the real module source.  The module is
+hidden and dies with a message similar to the one that would happen if it
+weren't installed.
 
 =cut
 


### PR DESCRIPTION
Using a die directly in the `@INC` hook matches perl's behavior for a
missing module closer than using a fake module that dies.  It is also
simpler and more compatible.

On perl 5.8, with a die inside a module, the `%INC` entry will be left
behind.  Later attempts to load the module will then appear to succeed.
Putting the die directly will leave the `%INC` entry non-existent, just
like if the file does not exist.

This also avoids PerlIO, so it works on perl 5.6 without any extra work.

The error message was also updated to include ` in @INC`, so it is
closer to the error provided by perl.  This is expected by some modules
handling optional loads, such as Class::Load.

The behaviors are demonstrated in https://gist.github.com/haarg/c55c702c08fc59a8d61b1265f1c07353