### PR TITLE
Simplify even further

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for Acme-Devel-Hide-Tiny
 
 {{$NEXT}}
 
+    - Updated: simplified even further
+
 0.002     2017-02-15 08:17:00-05:00 America/New_York
 
     - Updated: simplified (dies directly in hook) and better

--- a/lib/Acme/Devel/Hide/Tiny.pm
+++ b/lib/Acme/Devel/Hide/Tiny.pm
@@ -14,45 +14,19 @@ our $VERSION = '0.003';
     # in 'foo.t', assume we want to hide Cpanel::JSON::XS
 
     # hide Cpanel::JSON::XS -> Cpanel/JSON/XS.pm
-    use lib map {
-        my $m = $_;
-        sub { return unless $_[1] eq $m; die "Can't locate $_[1] in \@INC (hidden)\n"; }
-    } qw{Cpanel/JSON/XS.pm};
+    use lib sub {
+        return unless $_[1] eq q{Cpanel/JSON/XS.pm};
+        die "Can't locate $_[1] in \@INC (hidden)\n";
+    };
 
 =head1 DESCRIPTION
 
 The L<Devel::Hide> and L<Test::Without::Module> modules are very helpful
 development tools.  Unfortunately, using them in your F<.t> files adds a
 test dependency.  Maybe you don't want to do that.
-
-Instead, you can use the one-liner from the SYNOPSIS above, which is an
+Instead, you can use the code from the L</SYNOPSIS> above, which is an
 extremely stripped down version of L<Devel::Hide>.
-
-Here is a more verbose, commented version of it:
-
-    # 'lib' adds its arguments to the front of @INC
-    use lib
-
-        # add one coderef per path to hide
-        map {
-            # create lexical for module
-            my $m = $_;
-
-            # construct and return a closure that dies for the module path to hide
-            sub {
-
-                # return if not the path to hide; perl checks rest of @INC
-                return unless $_[1] eq $m;
-
-                # die with the error message we want
-                die "Can't locate $_[1] in \@INC (hidden)\n";
-            }
-        }
-
-        # input to map is a list module names, converted to paths;
-        qw{Cpanel/JSON/XS.pm JSON/XS.pm}
-
-    ; # end of 'use lib' statement
+To hide multiple modules, simply repeat the C<return unless> line.
 
 When perl sees a coderef in C<@INC>, it gives the coderef a chance to
 provide the source code of that module.  In this case, if the path is the


### PR DESCRIPTION
it’s superfluous to use a `map` to create multiple closures (which require setting up a lexical that can be captured) which then each only hide one module. Using dumber code makes the pattern both easier to remember and cleaner in terms of implementation.